### PR TITLE
Address PHP 8.4 deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ licensed under the [MIT license](LICENSE.md).
 
 ## Installation
 
-To use the library you need PHP 5.6 and [Composer](https://getcomposer.org/).
+To use the library you need PHP 7.1 and [Composer](https://getcomposer.org/).
 Add the following entry to your `composer.json`.
 
 ```shell

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   },
   "require": {
-    "php": ">=5.6"
+    "php": ">=7.1"
   },
   "require-dev": {
     "phpunit/phpunit": "4.8.*",

--- a/src/Converter/AbstractConverter.php
+++ b/src/Converter/AbstractConverter.php
@@ -18,7 +18,7 @@ abstract class AbstractConverter implements ConverterInterface
     /**
      * @param ChecksumCalculatorInterface $checksumCalculator
      */
-    public function __construct(ChecksumCalculatorInterface $checksumCalculator = null)
+    public function __construct(?ChecksumCalculatorInterface $checksumCalculator = null)
     {
         $this->checksumCalculator = $checksumCalculator;
     }

--- a/src/Converter/Converter.php
+++ b/src/Converter/Converter.php
@@ -18,7 +18,7 @@ class Converter extends AbstractConverter
     /**
      * @param ConverterInterface[][] $converterMap
      */
-    public function __construct(array $converterMap = null)
+    public function __construct(?array $converterMap = null)
     {
         parent::__construct();
 

--- a/src/Converter/Ean13Converter.php
+++ b/src/Converter/Ean13Converter.php
@@ -12,7 +12,7 @@ use Rebuy\EanIsbn\Internal\Ean13ChecksumCalculator;
 
 class Ean13Converter extends AbstractConverter
 {
-    public function __construct(ChecksumCalculatorInterface $checksumCalculator = null)
+    public function __construct(?ChecksumCalculatorInterface $checksumCalculator = null)
     {
         parent::__construct($checksumCalculator ?: new Ean13ChecksumCalculator());
     }

--- a/src/Converter/Isbn10Converter.php
+++ b/src/Converter/Isbn10Converter.php
@@ -11,7 +11,7 @@ use Rebuy\EanIsbn\Internal\Isbn10ChecksumCalculator;
 
 class Isbn10Converter extends AbstractConverter
 {
-    public function __construct(ChecksumCalculatorInterface $checksumCalculator = null)
+    public function __construct(?ChecksumCalculatorInterface $checksumCalculator = null)
     {
         parent::__construct($checksumCalculator ?: new Isbn10ChecksumCalculator());
     }

--- a/src/Parser/AbstractParser.php
+++ b/src/Parser/AbstractParser.php
@@ -15,7 +15,7 @@ abstract class AbstractParser implements ParserInterface
     /**
      * @param ChecksumCalculatorInterface $checksumCalculator
      */
-    public function __construct(ChecksumCalculatorInterface $checksumCalculator = null)
+    public function __construct(?ChecksumCalculatorInterface $checksumCalculator = null)
     {
         $this->checksumCalculator = $checksumCalculator;
     }

--- a/src/Parser/Ean13Parser.php
+++ b/src/Parser/Ean13Parser.php
@@ -8,7 +8,7 @@ use Rebuy\EanIsbn\Internal\Ean13ChecksumCalculator;
 
 class Ean13Parser extends AbstractParser
 {
-    public function __construct(ChecksumCalculatorInterface $checksumCalculator = null)
+    public function __construct(?ChecksumCalculatorInterface $checksumCalculator = null)
     {
         parent::__construct($checksumCalculator ?: new Ean13ChecksumCalculator());
     }

--- a/src/Parser/Ean8Parser.php
+++ b/src/Parser/Ean8Parser.php
@@ -10,7 +10,7 @@ class Ean8Parser extends AbstractParser
 {
     private static $ean8ToEan13Prefix = '00000';
 
-    public function __construct(ChecksumCalculatorInterface $checksumCalculator = null)
+    public function __construct(?ChecksumCalculatorInterface $checksumCalculator = null)
     {
         parent::__construct($checksumCalculator ?: new Ean13ChecksumCalculator());
     }

--- a/src/Parser/Isbn10Parser.php
+++ b/src/Parser/Isbn10Parser.php
@@ -8,7 +8,7 @@ use Rebuy\EanIsbn\Internal\Isbn10ChecksumCalculator;
 
 class Isbn10Parser extends AbstractParser
 {
-    public function __construct(ChecksumCalculatorInterface $checksumCalculator = null)
+    public function __construct(?ChecksumCalculatorInterface $checksumCalculator = null)
     {
         parent::__construct($checksumCalculator ?: new Isbn10ChecksumCalculator());
     }

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -14,7 +14,7 @@ class Parser implements ParserInterface
     /**
      * @param ParserInterface[] $parsers
      */
-    public function __construct(array $parsers = null)
+    public function __construct(?array $parsers = null)
     {
         $this->parsers = $parsers ?: [
             new Ean8Parser(),


### PR DESCRIPTION
Since PHP 8.4, it is deprecated to marking a parameter as implicitly nullable.
The syntax allowing to fix the deprecation was introduced in PHP 7.1, so let us bump the minimum version to that.